### PR TITLE
MTL-1708 Built SP4 and SP3 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.4 AS base
+ARG SLE_VERSION
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${SLE_VERSION} AS base
 
 RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
 CMD ["/bin/bash"]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -28,6 +28,9 @@
 // Find the latest go-version here: https://go.dev/VERSION?m=text
 def goVersion = '1.19'
 
+// Define the distro that the major.minor and major.minor.patch Docker tags publish to.
+def mainSleVersion = '15.4'
+
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
     currentBuild.result = 'SUCCESS'
@@ -65,39 +68,64 @@ pipeline {
 
     stages {
 
-        stage('Build') {
-            steps {
-                withCredentials([
-                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
-                ]) {
-                    sh "make image"
+        stage('Build & Publish') {
+
+            matrix {
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
                 }
-            }
-        }
 
-        stage('Publish') {
-            steps {
-                script {
+                stages {
 
-                    // Only overwrite an image if this is a stable build.
-                    if (isStable) {
-                        /*
-                        Publish these tags on stable:
-                            - Major.Minor-Hash-Timestamp    (e.g. 1.18-dhckj3-20221017133121)
-                            - Major.Minor-Hash-Timestamp    (e.g. 1.18-dhckj3)
-                            - Major.Minor                   (e.g. 1.18)
-                        */
-                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-${env.VERSION}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                    } else {
-                        /*
-                        Publish these tags on unstable:
-                            - Hash                          (e.g. dhckj3)
-                            - Hash-Timestamp                (e.g. dhckj3-20221017133121)
-                        */
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                    stage('Build') {
+                        environment {
+                            SLE_VERSION = "${sleVersion}"
+                        }
+                        steps {
+                            withCredentials([
+                                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
+                            ]) {
+                                sh "make image"
+                            }
+                        }
+                    }
+
+                    stage('Publish') {
+                        steps {
+                            script {
+
+                                // Only overwrite an image if this is a stable build.
+                                if (isStable) {
+                                    /*
+                                    Publish these tags on stable:
+                                        - Major.Minor-Hash-Timestamp    (e.g. 1.18-SLES15.4-dhckj3-20221017133121)
+                                        - Major.Minor-Hash-Timestamp    (e.g. 1.18-SLES15.4-dhckj3)
+                                        - Major.Minor                   (e.g. 1.18-SLES15.4)
+                                        - Major.Minor                   (e.g. 1.18)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}", isStable: isStable)
+
+                                    // Only publish the simple version images on the latest/newest base image.
+                                    if ("${sleVersion}" == "${mainSleVersion}") {
+                                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}", isStable: isStable)
+                                    }
+                                } else {
+                                    /*
+                                    Publish these tags on unstable:
+                                        - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
+                                        - Hash                          (e.g. SLES15.4-dhckj3)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,9 @@
 
 A SLE Server GoLang Docker image used for RPM builds.
 
+Available images can only be seen by querying the Docker API or
+https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-go[visiting the registry itself].
+
 == Building
 
 The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` command. The commands below are for use outside the CSM Jenkins Pipeline.
@@ -26,8 +29,8 @@ docker build --secret id=SLES_REGISTRATION_CODE --build-arg GO_VERSION=go1.19 .
 # Go Version
 docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:1.19
 
-# Git Hash
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:<hash>
+# Go Version and distro
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:1.19-SLES15.4
 ----
 
 == GoLang Version(s)
@@ -36,14 +39,16 @@ The version is controlled by the `Jenkinsfile`.
 
 Unstable image tags will publish using these tags:
 
-* `[HASH]`
-* `[HASH]-[TIMESTAMP]`
+* `[DISTRO]-[HASH]`
+* `[DISTRO]-[HASH]-[TIMESTAMP]`
 
 Stable image tags will publish using these tags:
 
+.The `[MAJOR.MINOR]` image is only created against the latest distro.
 * `[MAJOR.MINOR]`
-* `[MAJOR.MINOR]-[HASH]`
-* `[MAJOR.MINOR]-[HASH]-[TIMESTAMP]`
+* `[MAJOR.MINOR]-[DISTRO]`
+* `[MAJOR.MINOR]-[DISTRO]-[HASH]`
+* `[MAJOR.MINOR]-[DISTRO]-[HASH]-[TIMESTAMP]`
 
 === Updating GO
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This implements a matrix to build against any SLES base image and publishes more specific Docker containing the distro information.

A basic tag will still be provided that contains just the Go version, however this tag will only be published for whichever SLES version is set in `mainSleVersion` in the `Jenkinsfile`. So `csm-docker-sle-go:1.19` will be built on SP4, but a user could use `csm-docker-sle-go:1.19-SLES15.3` to grab the SP3 base version.

Lastly the `Makefile` was modified to work outside of our Jenkins environment in order to facilitate local development.

**Example tags:**

*Stable:*
- csm-docker-sle-go:1.19-SLES15.3-dhckj3-20221017133121
- csm-docker-sle-go:1.19-SLES15.3-dhckj3
- csm-docker-sle-go:1.19-SLES15.3
- csm-docker-sle-go:1.19-SLES15.4-dhckj3-20221017133121
- csm-docker-sle-go:1.19-SLES15.4-dhckj3
- csm-docker-sle-go:1.19-SLES15.4
- csm-docker-sle-go:1.19

*Unstable:*
- csm-docker-sle-go:SLES15.3-dhckj3-20221017133121
- csm-docker-sle-go:SLES15.3-dhckj3
- csm-docker-sle-go:SLES15.4-dhckj3-20221017133121
- csm-docker-sle-go:SLES15.4-dhckj3

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
