### PR TITLE
Fix Clobbering Race Condition

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -74,17 +74,14 @@ pipeline {
 
                 axes {
                     axis {
-                        name 'sleVersion'
-                        values 15.3, 15.4
+                        name 'SLE_VERSION'
+                        values '15.3', '15.4'
                     }
                 }
 
                 stages {
 
                     stage('Build') {
-                        environment {
-                            SLE_VERSION = "${sleVersion}"
-                        }
                         steps {
                             withCredentials([
                                     string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
@@ -107,12 +104,13 @@ pipeline {
                                         - Major.Minor                   (e.g. 1.18-SLES15.4)
                                         - Major.Minor                   (e.g. 1.18)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}-${env.VERSION}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${sleVersion}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}", isStable: isStable)
 
                                     // Only publish the simple version images on the latest/newest base image.
-                                    if ("${sleVersion}" == "${mainSleVersion}") {
+                                    if ("${SLE_VERSION}" == "${mainSleVersion}") {
+                                        sh "docker tag ${env.NAME}:${goVersion}-SLES${mainSleVersion} ${env.NAME}:${goVersion}"
                                         publishCsmDockerImage(image: env.NAME, tag: "${goVersion}", isStable: isStable)
                                     }
                                 } else {
@@ -121,8 +119,8 @@ pipeline {
                                         - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
                                         - Hash                          (e.g. SLES15.4-dhckj3)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
                                 }
                             }
                         }

--- a/Makefile
+++ b/Makefile
@@ -20,27 +20,27 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 ifeq ($(NAME),)
-NAME := $(shell basename $(shell pwd))
+export NAME := $(shell basename $(shell pwd))
 endif
 
 ifeq ($(DOCKER_BUILDKIT),)
-DOCKER_BUILDKIT ?= 1
+export DOCKER_BUILDKIT ?= 1
 endif
 
 ifeq ($(GO_VERSION),)
-GO_VERSION := $(shell awk -v replace="'" '/goVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+export GO_VERSION := $(shell awk -v replace="'" '/goVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
 ifeq ($(SLE_VERSION),)
-SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+export SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
 ifeq ($(TIMESTAMP),)
-TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+export TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
 endif
 
 ifeq ($(VERSION),)
-VERSION ?= $(shell git rev-parse --short HEAD)
+export VERSION ?= $(shell git rev-parse --short HEAD)
 endif
 
 all: image
@@ -55,11 +55,9 @@ print:
 	@printf "%-20s: %s\n" Version $(VERSION)
 
 image: print
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION='${SLE_VERSION}' --build-arg GO_VERSION='go${GO_VERSION}' --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${GO_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${GO_VERSION}-SLES${SLE_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${GO_VERSION}-SLES${SLE_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}
+	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION='${SLE_VERSION}' --build-arg GO_VERSION='go${GO_VERSION}' --tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' .
+	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}'
+	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: https://github.com/Cray-HPE/csm-docker-sle-python/pull/21

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The 1.19 tagged images should correspond with the `mainSleVersion`, but this is not always true.

The past few 1.19 images I've pulled have been SP3. After inspecting build logs, there's a race condition due to a build agent overlap. Both the 15.3 and 15.4 stages run off the same `docker` process, and both take a `major.minor` and `hash` tag. Since both
take those same three tags, whichever build stage runs last ends up taking the tag to be published.

Even the the publishing stage only pushes the `major.minor` tag for the `mainSleVersion`, if the non-`mainSleVersion` took the tags last then its tags will end up getting published.

This removes the conflict by only taking the conflicting tags from Jenkins, meaning the matrix builds all take their own unique tags.

This gets rid of the `hash` tag, since it will always overlap and it was never actually pushed.

**This does not affect the `maint/` branches, because only `main` uses `matrix`.**

This also adds `export` to each variable definition in `Makefile`, ensuring that defaults are set for any context within the `Makefile`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
