### PR TITLE
CASM-3935 ARM support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,13 @@ FROM base AS go-base
 # Find the latest go-version here: https://go.dev/VERSION?m=text
 ARG GO_VERSION=''
 ENV GOCACHE=/tmp
+ARG TARGETPLATFORM
 
+RUN echo "${TARGETPLATFORM}"
 RUN if [ -z "${GO_VERSION}" ]; then export GO_VERSION="$(curl https://golang.org/VERSION?m=text)"; fi
 
-RUN curl -O "https://dl.google.com/go/$GO_VERSION.linux-amd64.tar.gz" \
-    && tar -C /usr/local -xzf "$GO_VERSION.linux-amd64.tar.gz"
+RUN curl -O "https://dl.google.com/go/$GO_VERSION.${TARGETPLATFORM//\//-}.tar.gz" \
+    && tar -C /usr/local -xzf "$GO_VERSION.${TARGETPLATFORM//\//-}.tar.gz"
 
 ENV PATH="$PATH:/usr/local/go/bin"
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -60,6 +60,7 @@ pipeline {
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Go.')
         DOCKER_BUILDKIT = 1
+        MULTI_ARCH = 1
         GO_VERSION = "${goVersion}"
         NAME = getRepoName()
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
@@ -82,6 +83,9 @@ pipeline {
                 stages {
 
                     stage('Build') {
+                        environment {
+                            BUILD_ARGS = "--build-arg 'SLE_VERSION=${SLE_VERSION}' --build-arg 'GO_VERSION=go${GO_VERSION}'"
+                        }
                         steps {
                             withCredentials([
                                     string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
@@ -92,6 +96,10 @@ pipeline {
                     }
 
                     stage('Publish') {
+                        environment {
+                            SLES_REGISTRATION_CODE = credentials('sles15-registration-code')
+                            BUILD_ARGS = "--build-arg 'SLE_VERSION=${SLE_VERSION}' --build-arg 'GO_VERSION=go${GO_VERSION}' --secret id=SLES_REGISTRATION_CODE"
+                        }
                         steps {
                             script {
 
@@ -104,14 +112,13 @@ pipeline {
                                         - Major.Minor                   (e.g. 1.18-SLES15.4)
                                         - Major.Minor                   (e.g. 1.18)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", multiArch: env.MULTI_ARCH, isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${goVersion}-SLES${SLE_VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
 
                                     // Only publish the simple version images on the latest/newest base image.
                                     if ("${SLE_VERSION}" == "${mainSleVersion}") {
-                                        sh "docker tag ${env.NAME}:${goVersion}-SLES${mainSleVersion} ${env.NAME}:${goVersion}"
-                                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}", isStable: isStable)
+                                        publishCsmDockerImage(image: env.NAME, tag: "${goVersion}", multiArch: env.MULTI_ARCH, isStable: isStable)
                                     }
                                 } else {
                                     /*
@@ -119,8 +126,8 @@ pipeline {
                                         - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
                                         - Hash                          (e.g. SLES15.4-dhckj3)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", multiArch: env.MULTI_ARCH, isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
                                 }
                             }
                         }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 # 
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -55,9 +55,11 @@ print:
 	@printf "%-20s: %s\n" Version $(VERSION)
 
 image: print
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION='${SLE_VERSION}' --build-arg GO_VERSION='go${GO_VERSION}' --tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' .
-	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
-	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
-	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}'
-	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}'
-	docker tag '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker buildx build --platform=linux/amd64,linux/arm64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --builder $$(docker buildx create --platform linux/amd64,linux/arm64) .
+	docker buildx create --use
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:${GO_VERSION}' .
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:SLES${SLE_VERSION}-${VERSION}' .
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}' .
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}' .
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}' .
+	docker buildx build --platform linux/amd64 ${BUILD_ARGS} --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --load -t '${NAME}:${GO_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}' .


### PR DESCRIPTION
add arm builds

### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASM-3935
- Requires: https://github.com/Cray-HPE/csm-shared-library/pull/47

#### Issue Type

- RFE Pull Request

Merge first: https://github.com/Cray-HPE/csm-shared-library/pull/47

Adds arm64 support for container images. Also allows ARM and x86 builds for multiple versions (ex. 15.3, 15.4)

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
yes
 
### Risks and Mitigations

Minimal risk
