### PR TITLE
User newer template and build 15.3 and 15.4 SLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3 AS base
+ARG SLE_VERSION
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${SLE_VERSION} AS base
 
 RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
 CMD ["/bin/bash"]
@@ -28,11 +29,13 @@ FROM base AS go-base
 # Find the latest go-version here: https://go.dev/VERSION?m=text
 ARG GO_VERSION=''
 ENV GOCACHE=/tmp
+ARG TARGETPLATFORM
 
-RUN if [ -z "${GO_VERSION}" ]; then export GO_VERSION="$(curl https://golang.org/VERSION?m=text)"; fi
+RUN echo "${TARGETPLATFORM}"
+RUN if [ -z "${GO_VERSION}" ]; then export GO_VERSION="$(curl https://go.dev/VERSION?m=text)"; fi
 
-RUN curl -O "https://dl.google.com/go/$GO_VERSION.linux-amd64.tar.gz" \
-    && tar -C /usr/local -xzf "$GO_VERSION.linux-amd64.tar.gz"
+RUN curl -O "https://dl.google.com/go/go$GO_VERSION.${TARGETPLATFORM//\//-}.tar.gz" \
+    && tar -C /usr/local -xzf "go$GO_VERSION.${TARGETPLATFORM//\//-}.tar.gz"
 
 ENV PATH="$PATH:/usr/local/go/bin"
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -28,6 +28,9 @@
 // Find the latest go-version here: https://go.dev/VERSION?m=text
 def goVersion = '1.16'
 
+// Define the distro that the major.minor and major.minor.patch Docker tags publish to.
+def mainSleVersion = '15.4'
+
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
     currentBuild.result = 'SUCCESS'
@@ -52,52 +55,77 @@ pipeline {
     }
 
     // Run every week on Sunday at 4 PM, long after the base image has rebuilt from that morning.
-    triggers{ cron('H 16 * * 0') }
+    triggers { cron('H 16 * * 0') }
 
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Go.')
         DOCKER_BUILDKIT = 1
+        MULTI_ARCH = 1
         GO_VERSION = "${goVersion}"
         NAME = getRepoName()
+        SLES_REGISTRATION_CODE = credentials('sles15-registration-code')
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
 
     stages {
 
-        stage('Build') {
-            steps {
-                withCredentials([
-                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
-                ]) {
-                    sh "make image"
+        stage('Build & Publish') {
+
+            matrix {
+
+                axes {
+                    axis {
+                        name 'SLE_VERSION'
+                        values '15.3', '15.4'
+                    }
                 }
-            }
-        }
 
-        stage('Publish') {
-            steps {
-                script {
+                environment {
+                    BUILD_ARGS = "--build-arg 'SLE_VERSION=${SLE_VERSION}' --build-arg 'GO_VERSION=${goVersion}' --secret id=SLES_REGISTRATION_CODE"
+                    SLE_VERSION = "${SLE_VERSION}"
+                }
 
-                    // Only overwrite an image if this is a stable build.
-                    if (isStable) {
-                        /*
-                        Publish these tags on stable:
-                            - Major.Minor-Hash-Timestamp    (e.g. 1.18-dhckj3-20221017133121)
-                            - Major.Minor-Hash-Timestamp    (e.g. 1.18-dhckj3)
-                            - Major.Minor                   (e.g. 1.18)
-                        */
-                        publishCsmDockerImage(image: env.NAME, isStable: isStable, tag: "${goVersion}")
-                        publishCsmDockerImage(image: env.NAME, isStable: isStable, tag: "${goVersion}-${env.VERSION}")
-                        publishCsmDockerImage(image: env.NAME, isStable: isStable, tag: "${goVersion}-${env.VERSION}-${env.TIMESTAMP}")
-                    } else {
-                        /*
-                        Publish these tags on unstable:
-                            - Hash                          (e.g. dhckj3)
-                            - Hash-Timestamp                (e.g. dhckj3-20221017133121)
-                        */
-                        publishCsmDockerImage(image: env.NAME, isStable: isStable, tag: "${env.VERSION}")
-                        publishCsmDockerImage(image: env.NAME, isStable: isStable, tag: "${env.VERSION}-${env.TIMESTAMP}")
+                stages {
+
+                    stage('Build') {
+                        steps {
+                            sh "make image"
+                        }
+                    }
+
+                    stage('Publish') {
+                        steps {
+                            script {
+
+                                // Only overwrite an image if this is a stable build.
+                                if (isStable) {
+                                    /*
+                                    Publish these tags on stable:
+                                        - Major.Minor-Hash-Timestamp    (e.g. 1.16-SLES15.4-dhckj3-20221017133121)
+                                        - Major.Minor-Hash-Timestamp    (e.g. 1.16-SLES15.4-dhckj3)
+                                        - Major.Minor                   (e.g. 1.16-SLES15.4)
+                                        - Major.Minor                   (e.g. 1.16)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${goVersion}-SLES${SLE_VERSION}")
+                                    publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}")
+                                    publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${goVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}")
+
+                                    // Only publish the simple version images on the latest/newest base image.
+                                    if ("${SLE_VERSION}" == "${mainSleVersion}") {
+                                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${goVersion}")
+                                    }
+                                } else {
+                                    /*
+                                    Publish these tags on unstable:
+                                        - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
+                                        - Hash                          (e.g. SLES15.4-dhckj3)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "SLES${SLE_VERSION}-${env.VERSION}")
+                                    publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}")
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
We are using a newer/cleaner `Makefile` and `Jenkinsfile.github` in our build envs for SLE and SLE-Python. This brings in those changes.

This also builds Go for multiple Go versions, both amd64 and aarch64.

Also fix the download URLs:
- New default URL is perm. redirected (seems updated throughout the repo except in the actual if conditional in the `Dockerfile`)
- All go tarballs are prefixed with `go`

**This PR is necessary before loftsman-rpm can modernize.**

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
