### PR TITLE
Builds keep timing out

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -49,7 +49,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "1"))
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 40, unit: 'MINUTES')
         disableConcurrentBuilds()
         timestamps()
     }


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm-docker-sle/pull/58
Doubles the timeout.